### PR TITLE
remove platform requirements in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,6 @@ let excludes = [
 
 let package = Package(
     name: "TreeSitterXML",
-    platforms: [.macOS(.v10_13), .iOS(.v11)],
     products: [
         .library(name: "TreeSitterXML", targets: ["TreeSitterXML", "TreeSitterDTD"]),
     ],


### PR DESCRIPTION
This requirement, which is not present in the Package.swift of tree-sitter-javascript, prevents installation on Xcode.