### PR TITLE
fix public headers in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,7 @@ let excludes = [
     "bindings/python",
     "bindings/rust",
     "common/common.mak",
-    "common/index.js"
-    "examples",
+    "common/index.js",
     "package.json",
     "package-lock.json",
     "pyproject.toml",

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
                 resources: [
                     .copy("queries/xml")
                 ],
-                publicHeadersPath: "bindings/swift",
+                publicHeadersPath: "bindings/swift/TreeSitterXML",
                 cSettings: [.headerSearchPath("xml/src")]),
         .target(name: "TreeSitterDTD",
                 path: ".",
@@ -62,7 +62,7 @@ let package = Package(
                 resources: [
                     .copy("queries/dtd")
                 ],
-                publicHeadersPath: "bindings/swift",
+                publicHeadersPath: "bindings/swift/TreeSitterDTD",
                 cSettings: [.headerSearchPath("dtd/src")])
     ],
     cLanguageStandard: .c11


### PR DESCRIPTION
This fixes an issue in Package.swift which causes the Swift compiler to complain about an umbrella already defined.