### PR TITLE
Add missing files to npm pkg to enable wasm builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "xml/package.json",
     "dtd/package.json",
     "xml/src/**",
-    "dtd/src/**"
+    "dtd/src/**",
+    "common/**"
   ],
   "dependencies": {
     "node-addon-api": "^8.0.0",


### PR DESCRIPTION
Hi there,
In [this project](https://github.com/simonacca/taste) I am building wasm parsers for a bunch of languages by installing the respective npm packages and then [reaching](https://github.com/simonacca/tASTe/blob/main/build-parsers.sh#L93-L95) into `node_modules` with `npx tree-sitter build --wasm  node_modules/tree-sitter-mylang --output parsers/mylang.wasm`.

At the moment this is broken for tree-sitter-xml because the `common` folder is not exported to the npm package.

As you can see in the repo, this happens to work for a lot of languages out there.

Would you be open to supporting this workflow in general on languages hosted under `tree-sitter-languages`?

Thanks!

Simon