### PR TITLE
fix(scanner): simplify string logic

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -21,7 +21,10 @@ fn main() {
         println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
     }
 
-    println!("cargo:rerun-if-changed={}", common_dir.join("scanner.h").to_str().unwrap());
+    println!(
+        "cargo:rerun-if-changed={}",
+        common_dir.join("scanner.h").to_str().unwrap()
+    );
 
     config.compile("tree-sitter-xml");
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -65,7 +65,6 @@ pub const XML_NODE_TYPES: &str = include_str!("../../xml/src/node-types.json");
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const DTD_NODE_TYPES: &str = include_str!("../../dtd/src/node-types.json");
 
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/dtd/src/parser.c
+++ b/dtd/src/parser.c
@@ -1171,33 +1171,15 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [333] = 287,
 };
 
-static inline bool aux_sym_PubidLiteral_token1_character_set_1(int32_t c) {
-  return (c < '\''
-    ? (c < ' '
-      ? (c < '\r'
-        ? c == '\n'
-        : c <= '\r')
-      : (c <= '!' || (c >= '#' && c <= '%')))
-    : (c <= ';' || (c < '_'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c >= 'a' && c <= 'z')))));
-}
+static TSCharacterRange aux_sym_PubidLiteral_token1_character_set_1[] = {
+  {'\n', '\n'}, {'\r', '\r'}, {' ', '!'}, {'#', '%'}, {'\'', ';'}, {'=', '='}, {'?', 'Z'}, {'_', '_'},
+  {'a', 'z'},
+};
 
-static inline bool aux_sym_PubidLiteral_token2_character_set_1(int32_t c) {
-  return (c < '('
-    ? (c < ' '
-      ? (c < '\r'
-        ? c == '\n'
-        : c <= '\r')
-      : (c <= '!' || (c >= '#' && c <= '%')))
-    : (c <= ';' || (c < '_'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c >= 'a' && c <= 'z')))));
-}
+static TSCharacterRange aux_sym_PubidLiteral_token2_character_set_1[] = {
+  {'\n', '\n'}, {'\r', '\r'}, {' ', '!'}, {'#', '%'}, {'(', ';'}, {'=', '='}, {'?', 'Z'}, {'_', '_'},
+  {'a', 'z'},
+};
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
@@ -1205,37 +1187,39 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(40);
-      if (lookahead == '"') ADVANCE(64);
-      if (lookahead == '#') ADVANCE(68);
-      if (lookahead == '%') ADVANCE(63);
-      if (lookahead == '&') ADVANCE(118);
-      if (lookahead == '\'') ADVANCE(78);
-      if (lookahead == '(') ADVANCE(46);
-      if (lookahead == ')') ADVANCE(49);
-      if (lookahead == '*') ADVANCE(50);
-      if (lookahead == '+') ADVANCE(52);
-      if (lookahead == ',') ADVANCE(53);
-      if (lookahead == '1') ADVANCE(66);
-      if (lookahead == ';') ADVANCE(80);
-      if (lookahead == '<') ADVANCE(1);
-      if (lookahead == '=') ADVANCE(133);
-      if (lookahead == '>') ADVANCE(45);
-      if (lookahead == '?') ADVANCE(51);
-      if (lookahead == 'E') ADVANCE(70);
-      if (lookahead == 'I') ADVANCE(67);
-      if (lookahead == 'N') ADVANCE(69);
-      if (lookahead == '[') ADVANCE(42);
-      if (lookahead == ']') ADVANCE(71);
-      if (lookahead == '_') ADVANCE(77);
-      if (lookahead == '|') ADVANCE(48);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(74);
-      if (lookahead == '-' ||
-          lookahead == '.' ||
-          lookahead == ':' ||
-          lookahead == 183) ADVANCE(76);
+      ADVANCE_MAP(
+        '"', 64,
+        '#', 68,
+        '%', 63,
+        '&', 118,
+        '\'', 78,
+        '(', 46,
+        ')', 49,
+        '*', 50,
+        '+', 52,
+        ',', 53,
+        '1', 66,
+        ';', 80,
+        '<', 1,
+        '=', 133,
+        '>', 45,
+        '?', 51,
+        'E', 70,
+        'I', 67,
+        'N', 69,
+        '[', 42,
+        ']', 71,
+        '_', 77,
+        '|', 48,
+        '\t', 74,
+        '\n', 74,
+        '\r', 74,
+        ' ', 74,
+        '-', 76,
+        '.', 76,
+        ':', 76,
+        0xb7, 76,
+      );
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(72);
@@ -1268,16 +1252,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '<') ADVANCE(79);
       END_STATE();
     case 5:
-      if (lookahead == '%') ADVANCE(63);
-      if (lookahead == '(') ADVANCE(46);
-      if (lookahead == '?') ADVANCE(9);
-      if (lookahead == 'E') ADVANCE(99);
-      if (lookahead == 'I') ADVANCE(82);
-      if (lookahead == 'N') ADVANCE(97);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(81);
+      ADVANCE_MAP(
+        '%', 63,
+        '(', 46,
+        '?', 9,
+        'E', 99,
+        'I', 82,
+        'N', 97,
+        '\t', 81,
+        '\n', 81,
+        '\r', 81,
+        ' ', 81,
+      );
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(120);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -1390,7 +1376,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 36:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(131);
@@ -1406,28 +1392,30 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 39:
       if (eof) ADVANCE(40);
-      if (lookahead == '"') ADVANCE(64);
-      if (lookahead == '#') ADVANCE(22);
-      if (lookahead == '%') ADVANCE(63);
-      if (lookahead == '\'') ADVANCE(78);
-      if (lookahead == '(') ADVANCE(46);
-      if (lookahead == ')') ADVANCE(49);
-      if (lookahead == '*') ADVANCE(50);
-      if (lookahead == '+') ADVANCE(52);
-      if (lookahead == ',') ADVANCE(53);
-      if (lookahead == '1') ADVANCE(7);
-      if (lookahead == ';') ADVANCE(80);
-      if (lookahead == '<') ADVANCE(1);
-      if (lookahead == '=') ADVANCE(133);
-      if (lookahead == '>') ADVANCE(45);
-      if (lookahead == '?') ADVANCE(51);
-      if (lookahead == '[') ADVANCE(42);
-      if (lookahead == ']') ADVANCE(34);
-      if (lookahead == '|') ADVANCE(48);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(81);
+      ADVANCE_MAP(
+        '"', 64,
+        '#', 22,
+        '%', 63,
+        '\'', 78,
+        '(', 46,
+        ')', 49,
+        '*', 50,
+        '+', 52,
+        ',', 53,
+        '1', 7,
+        ';', 80,
+        '<', 1,
+        '=', 133,
+        '>', 45,
+        '?', 51,
+        '[', 42,
+        ']', 34,
+        '|', 48,
+        '\t', 81,
+        '\n', 81,
+        '\r', 81,
+        ' ', 81,
+      );
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(113);
@@ -1479,7 +1467,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == 'R') ADVANCE(83);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1496,13 +1484,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == 'S') ADVANCE(58);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1519,12 +1507,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1540,7 +1528,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(anon_sym_POUNDREQUIRED);
@@ -1571,13 +1559,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'D') ADVANCE(54);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1596,7 +1584,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'M') ADVANCE(106);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1608,7 +1596,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'N') ADVANCE(105);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
@@ -1625,7 +1613,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 72:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
@@ -1638,7 +1626,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 73:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1664,7 +1652,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
@@ -1674,7 +1662,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
@@ -1684,7 +1672,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
@@ -1711,13 +1699,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(89);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1729,7 +1717,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(98);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1741,7 +1729,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(103);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1758,7 +1746,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_Name);
@@ -1769,7 +1757,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_Name);
@@ -1780,13 +1768,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'F') ADVANCE(56);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1803,13 +1791,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'I') ADVANCE(107);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1822,7 +1810,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'I') ADVANCE(85);
       if (lookahead == 'Y') ADVANCE(58);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1839,7 +1827,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_Name);
@@ -1851,13 +1839,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'K') ADVANCE(84);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1874,7 +1862,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_Name);
@@ -1885,13 +1873,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'N') ADVANCE(56);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1908,7 +1896,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_Name);
@@ -1919,13 +1907,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'O') ADVANCE(95);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1942,13 +1930,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'S') ADVANCE(58);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1965,13 +1953,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(91);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1983,7 +1971,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(101);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1995,7 +1983,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(92);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2012,7 +2000,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_Name);
@@ -2023,7 +2011,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_Name);
@@ -2034,12 +2022,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(111);
@@ -2052,7 +2040,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 112:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2068,7 +2056,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(113);
+          lookahead == 0xb7) ADVANCE(113);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2079,7 +2067,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2092,7 +2080,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2105,7 +2093,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2115,7 +2103,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(117);
+          lookahead == 0xb7) ADVANCE(117);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(anon_sym_AMP);
@@ -2156,11 +2144,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 127:
       ACCEPT_TOKEN(aux_sym_PubidLiteral_token1);
-      if (aux_sym_PubidLiteral_token1_character_set_1(lookahead)) ADVANCE(127);
+      if (set_contains(aux_sym_PubidLiteral_token1_character_set_1, 9, lookahead)) ADVANCE(127);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(aux_sym_PubidLiteral_token2);
-      if (aux_sym_PubidLiteral_token2_character_set_1(lookahead)) ADVANCE(128);
+      if (set_contains(aux_sym_PubidLiteral_token2_character_set_1, 9, lookahead)) ADVANCE(128);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(anon_sym_LT_QMARK);
@@ -2194,16 +2182,18 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (lookahead == 'A') ADVANCE(1);
-      if (lookahead == 'C') ADVANCE(2);
-      if (lookahead == 'E') ADVANCE(3);
-      if (lookahead == 'I') ADVANCE(4);
-      if (lookahead == 'N') ADVANCE(5);
-      if (lookahead == 'P') ADVANCE(6);
-      if (lookahead == 'S') ADVANCE(7);
-      if (lookahead == 'e') ADVANCE(8);
-      if (lookahead == 'v') ADVANCE(9);
-      if (lookahead == 'x') ADVANCE(10);
+      ADVANCE_MAP(
+        'A', 1,
+        'C', 2,
+        'E', 3,
+        'I', 4,
+        'N', 5,
+        'P', 6,
+        'S', 7,
+        'e', 8,
+        'v', 9,
+        'x', 10,
+      );
       END_STATE();
     case 1:
       if (lookahead == 'N') ADVANCE(11);
@@ -5831,13 +5821,13 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
-  [17] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(116),
-  [20] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(145),
-  [23] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(294),
-  [26] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(2),
-  [29] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(302),
-  [32] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(37),
+  [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [17] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(116),
+  [20] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(145),
+  [23] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(294),
+  [26] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(2),
+  [29] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(302),
+  [32] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(37),
   [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
   [37] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
   [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
@@ -5845,9 +5835,9 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
   [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 0),
   [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1),
+  [53] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
   [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
   [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
   [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
@@ -5856,42 +5846,42 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [65] = {.entry = {.count = 1, .reusable = false}}, SHIFT(323),
   [67] = {.entry = {.count = 1, .reusable = false}}, SHIFT(324),
   [69] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
-  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(326),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(13),
-  [79] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(285),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(286),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(287),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 1),
+  [71] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(326),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0),
+  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(13),
+  [79] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(285),
+  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(286),
+  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(287),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 1, 0, 0),
   [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
   [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
   [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
   [96] = {.entry = {.count = 1, .reusable = false}}, SHIFT(285),
   [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(286),
   [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
-  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(330),
-  [105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2),
-  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(17),
-  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(323),
-  [113] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(324),
-  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(325),
+  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(330),
+  [105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0),
+  [107] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(17),
+  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(323),
+  [113] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(324),
+  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(325),
   [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
   [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
   [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEReference, 3),
+  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEReference, 3, 0, 0),
   [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
   [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(240),
   [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
   [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 5),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 3),
+  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 5, 0, 0),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 3, 0, 0),
   [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
   [141] = {.entry = {.count = 1, .reusable = false}}, SHIFT(331),
   [143] = {.entry = {.count = 1, .reusable = false}}, SHIFT(332),
   [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
   [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 6),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 4),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 6, 0, 0),
+  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 4, 0, 0),
   [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
   [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
   [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
@@ -5903,71 +5893,71 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(289),
   [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
   [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2),
-  [177] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(331),
-  [180] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(332),
-  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(333),
-  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(30),
+  [175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0),
+  [177] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(331),
+  [180] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(332),
+  [183] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(333),
+  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(30),
   [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2),
-  [193] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(327),
-  [196] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(328),
-  [199] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(329),
-  [202] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(32),
-  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 7),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0),
+  [193] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(327),
+  [196] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(328),
+  [199] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(329),
+  [202] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 7, 0, 0),
   [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 8),
-  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 8),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 6),
-  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 6),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__markupdecl, 1),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__markupdecl, 1),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 7),
-  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 7),
+  [209] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 8, 0, 0),
+  [211] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 8, 0, 0),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 6, 0, 0),
+  [215] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 6, 0, 0),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__markupdecl, 1, 0, 0),
+  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__markupdecl, 1, 0, 0),
+  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 7, 0, 0),
+  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 7, 0, 0),
   [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
   [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
   [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
   [231] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 7),
-  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elementdecl, 7),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 3),
-  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 3),
-  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEReference, 3),
-  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 7),
-  [245] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_NotationDecl, 7),
+  [233] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 7, 0, 0),
+  [235] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elementdecl, 7, 0, 0),
+  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 3, 0, 0),
+  [239] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 3, 0, 0),
+  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEReference, 3, 0, 0),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 7, 0, 0),
+  [245] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_NotationDecl, 7, 0, 0),
   [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
   [249] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
   [251] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 8),
-  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_NotationDecl, 8),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 8),
-  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elementdecl, 8),
+  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 8, 0, 0),
+  [255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_NotationDecl, 8, 0, 0),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 8, 0, 0),
+  [259] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elementdecl, 8, 0, 0),
   [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
   [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 5),
-  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 5),
-  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 6),
-  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 6),
-  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 7),
-  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 7),
-  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 4),
-  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 4),
-  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 5),
-  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 5),
+  [265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 5, 0, 0),
+  [267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 5, 0, 0),
+  [269] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 6, 0, 0),
+  [271] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 6, 0, 0),
+  [273] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 7, 0, 0),
+  [275] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 7, 0, 0),
+  [277] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 4, 0, 0),
+  [279] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 4, 0, 0),
+  [281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 5, 0, 0),
+  [283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_AttlistDecl, 5, 0, 0),
   [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
   [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 7),
-  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 7),
-  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EntityDecl, 1),
-  [295] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__EntityDecl, 1),
-  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 9),
-  [299] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEDecl, 9),
-  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 9),
-  [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 9),
-  [305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 5),
-  [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 5),
-  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 10),
-  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEDecl, 10),
+  [289] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditionalSect, 7, 0, 0),
+  [291] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_conditionalSect, 7, 0, 0),
+  [293] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EntityDecl, 1, 0, 0),
+  [295] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__EntityDecl, 1, 0, 0),
+  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 9, 0, 0),
+  [299] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEDecl, 9, 0, 0),
+  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 9, 0, 0),
+  [303] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_GEDecl, 9, 0, 0),
+  [305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 5, 0, 0),
+  [307] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 5, 0, 0),
+  [309] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 10, 0, 0),
+  [311] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEDecl, 10, 0, 0),
   [313] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
   [315] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
   [317] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
@@ -5981,14 +5971,14 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
   [335] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
   [337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 6),
-  [341] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 6),
-  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CharRef, 3),
-  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CharRef, 3),
-  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityRef, 3),
-  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EntityRef, 3),
-  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Reference, 1),
-  [353] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__Reference, 1),
+  [339] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 6, 0, 0),
+  [341] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 6, 0, 0),
+  [343] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CharRef, 3, 0, 0),
+  [345] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CharRef, 3, 0, 0),
+  [347] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityRef, 3, 0, 0),
+  [349] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EntityRef, 3, 0, 0),
+  [351] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Reference, 1, 0, 0),
+  [353] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__Reference, 1, 0, 0),
   [355] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
   [357] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
   [359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(247),
@@ -5997,37 +5987,37 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [365] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
   [367] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
   [369] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 5),
-  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 5),
+  [371] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 5, 0, 0),
+  [373] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 5, 0, 0),
   [375] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
-  [377] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2), SHIFT_REPEAT(64),
-  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2),
-  [382] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2), SHIFT_REPEAT(228),
-  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 4),
-  [387] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 4),
+  [377] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [380] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0),
+  [382] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0), SHIFT_REPEAT(228),
+  [385] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 4, 0, 0),
+  [387] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 4, 0, 0),
   [389] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
   [391] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
   [393] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 2),
-  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 4),
+  [395] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 2, 0, 0),
+  [397] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 4, 0, 0),
   [399] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2),
-  [403] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2), SHIFT_REPEAT(322),
-  [406] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2), SHIFT_REPEAT(229),
-  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 3),
-  [411] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2), SHIFT_REPEAT(130),
-  [414] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2),
-  [416] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2), SHIFT_REPEAT(259),
-  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 1),
+  [401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0),
+  [403] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0), SHIFT_REPEAT(322),
+  [406] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0), SHIFT_REPEAT(229),
+  [409] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 3, 0, 0),
+  [411] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0), SHIFT_REPEAT(130),
+  [414] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0),
+  [416] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0), SHIFT_REPEAT(259),
+  [419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 1, 0, 0),
   [421] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
   [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
   [425] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
   [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
   [429] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
   [431] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2),
-  [435] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(124),
-  [438] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(277),
+  [433] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0),
+  [435] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(124),
+  [438] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(277),
   [441] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
   [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
   [445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(246),
@@ -6037,39 +6027,39 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(207),
   [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
   [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2),
-  [461] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2), SHIFT_REPEAT(322),
+  [459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2, 0, 0),
+  [461] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2, 0, 0), SHIFT_REPEAT(322),
   [464] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
   [466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
-  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1),
-  [470] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1), SHIFT_REPEAT(119),
+  [468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1, 0, 0),
+  [470] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1, 0, 0), SHIFT_REPEAT(119),
   [473] = {.entry = {.count = 1, .reusable = true}}, SHIFT(143),
   [475] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
   [477] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
   [479] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
-  [481] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2),
-  [483] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2), SHIFT_REPEAT(170),
+  [481] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0),
+  [483] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0), SHIFT_REPEAT(170),
   [486] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
   [488] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
-  [490] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(133),
+  [490] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(133),
   [493] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
-  [495] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 3),
-  [497] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2), SHIFT_REPEAT(231),
-  [500] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2),
-  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2), SHIFT_REPEAT(274),
+  [495] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 3, 0, 0),
+  [497] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0), SHIFT_REPEAT(231),
+  [500] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0),
+  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0), SHIFT_REPEAT(274),
   [505] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
   [507] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
   [509] = {.entry = {.count = 1, .reusable = true}}, SHIFT(189),
   [511] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [513] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
   [515] = {.entry = {.count = 1, .reusable = true}}, SHIFT(268),
-  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 4),
-  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 3),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 4, 0, 0),
+  [519] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 3, 0, 0),
   [521] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
   [523] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
   [525] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
   [527] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
-  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 6),
+  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 6, 0, 0),
   [531] = {.entry = {.count = 1, .reusable = true}}, SHIFT(209),
   [533] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
   [535] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
@@ -6078,19 +6068,19 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [541] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
   [543] = {.entry = {.count = 1, .reusable = true}}, SHIFT(265),
   [545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 4),
+  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 4, 0, 0),
   [549] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
   [551] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 3),
+  [553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 3, 0, 0),
   [555] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
   [557] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
   [559] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [561] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 1),
+  [561] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 1, 0, 0),
   [563] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
   [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 1),
+  [567] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 1, 0, 0),
   [569] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
-  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 3),
+  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 3, 0, 0),
   [573] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
   [575] = {.entry = {.count = 1, .reusable = true}}, SHIFT(298),
   [577] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
@@ -6098,59 +6088,59 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [581] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
   [583] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
   [585] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
-  [587] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 4),
+  [587] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 4, 0, 0),
   [589] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 5),
+  [591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 5, 0, 0),
   [593] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [595] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 2),
+  [595] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 2, 0, 0),
   [597] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [599] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 6),
-  [601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 7),
+  [599] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 6, 0, 0),
+  [601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 7, 0, 0),
   [603] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
   [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
   [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
   [609] = {.entry = {.count = 1, .reusable = true}}, SHIFT(301),
-  [611] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__VersionInfo, 6),
+  [611] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__VersionInfo, 6, 0, 0),
   [613] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
   [615] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
   [617] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
-  [619] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 9),
-  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 8),
+  [619] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 9, 0, 0),
+  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 8, 0, 0),
   [623] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [625] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
   [627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(188),
   [629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(299),
-  [631] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 4),
+  [631] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 4, 0, 0),
   [633] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [635] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 3),
+  [635] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 3, 0, 0),
   [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
   [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
   [641] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
-  [643] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 6),
-  [645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EnumeratedType, 1),
+  [643] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 6, 0, 0),
+  [645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EnumeratedType, 1, 0, 0),
   [647] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
   [649] = {.entry = {.count = 1, .reusable = true}}, SHIFT(295),
-  [651] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 3),
-  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 6),
-  [655] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 2),
-  [657] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 8),
-  [659] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 3, .production_id = 1),
-  [661] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 2),
-  [663] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 3),
+  [651] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 3, 0, 0),
+  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 6, 0, 0),
+  [655] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 2, 0, 0),
+  [657] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 8, 0, 0),
+  [659] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 3, 0, 1),
+  [661] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 2, 0, 0),
+  [663] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 3, 0, 0),
   [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(196),
   [667] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
   [669] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
   [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [673] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 5),
-  [675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 7),
+  [673] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 5, 0, 0),
+  [675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 7, 0, 0),
   [677] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
   [679] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
   [681] = {.entry = {.count = 1, .reusable = true}}, SHIFT(245),
   [683] = {.entry = {.count = 1, .reusable = true}}, SHIFT(300),
-  [685] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 2),
-  [687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PublicID, 3),
+  [685] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 2, 0, 0),
+  [687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PublicID, 3, 0, 0),
   [689] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
-  [691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EncodingDecl, 6),
+  [691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EncodingDecl, 6, 0, 0),
   [693] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
   [695] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
   [697] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
@@ -6160,26 +6150,26 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [705] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
   [707] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
   [709] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
-  [711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 4),
+  [711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 4, 0, 0),
   [713] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 3, .production_id = 1),
-  [717] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2), SHIFT(21),
+  [715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 3, 0, 1),
+  [717] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0), SHIFT(21),
   [720] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
   [722] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
-  [724] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 3),
+  [724] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 3, 0, 0),
   [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(261),
   [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
   [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
   [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 1),
-  [736] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NDataDecl, 4),
-  [738] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_contentspec, 1),
+  [734] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 1, 0, 0),
+  [736] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NDataDecl, 4, 0, 0),
+  [738] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_contentspec, 1, 0, 0),
   [740] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
   [742] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
-  [744] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__AttType, 1),
-  [746] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_SystemLiteral, 3),
-  [748] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PubidLiteral, 3),
-  [750] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 5),
+  [744] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__AttType, 1, 0, 0),
+  [746] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_SystemLiteral, 3, 0, 0),
+  [748] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PubidLiteral, 3, 0, 0),
+  [750] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 5, 0, 0),
   [752] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
   [754] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
   [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
@@ -6297,7 +6287,7 @@ void tree_sitter_dtd_external_scanner_deserialize(void *, const char *, unsigned
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_dtd() {
+TS_PUBLIC const TSLanguage *tree_sitter_dtd(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/dtd/src/tree_sitter/parser.h
+++ b/dtd/src/tree_sitter/parser.h
@@ -86,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -125,6 +130,24 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
@@ -152,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -203,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/xml/src/parser.c
+++ b/xml/src/parser.c
@@ -1581,33 +1581,15 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [494] = 443,
 };
 
-static inline bool aux_sym_PubidLiteral_token1_character_set_1(int32_t c) {
-  return (c < '\''
-    ? (c < ' '
-      ? (c < '\r'
-        ? c == '\n'
-        : c <= '\r')
-      : (c <= '!' || (c >= '#' && c <= '%')))
-    : (c <= ';' || (c < '_'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c >= 'a' && c <= 'z')))));
-}
+static TSCharacterRange aux_sym_PubidLiteral_token1_character_set_1[] = {
+  {'\n', '\n'}, {'\r', '\r'}, {' ', '!'}, {'#', '%'}, {'\'', ';'}, {'=', '='}, {'?', 'Z'}, {'_', '_'},
+  {'a', 'z'},
+};
 
-static inline bool aux_sym_PubidLiteral_token2_character_set_1(int32_t c) {
-  return (c < '('
-    ? (c < ' '
-      ? (c < '\r'
-        ? c == '\n'
-        : c <= '\r')
-      : (c <= '!' || (c >= '#' && c <= '%')))
-    : (c <= ';' || (c < '_'
-      ? (c < '?'
-        ? c == '='
-        : c <= 'Z')
-      : (c <= '_' || (c >= 'a' && c <= 'z')))));
-}
+static TSCharacterRange aux_sym_PubidLiteral_token2_character_set_1[] = {
+  {'\n', '\n'}, {'\r', '\r'}, {' ', '!'}, {'#', '%'}, {'(', ';'}, {'=', '='}, {'?', 'Z'}, {'_', '_'},
+  {'a', 'z'},
+};
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
   START_LEXER();
@@ -1615,38 +1597,40 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   switch (state) {
     case 0:
       if (eof) ADVANCE(42);
-      if (lookahead == '"') ADVANCE(67);
-      if (lookahead == '#') ADVANCE(72);
-      if (lookahead == '%') ADVANCE(66);
-      if (lookahead == '&') ADVANCE(121);
-      if (lookahead == '\'') ADVANCE(81);
-      if (lookahead == '(') ADVANCE(49);
-      if (lookahead == ')') ADVANCE(52);
-      if (lookahead == '*') ADVANCE(53);
-      if (lookahead == '+') ADVANCE(55);
-      if (lookahead == ',') ADVANCE(56);
-      if (lookahead == '/') ADVANCE(70);
-      if (lookahead == '1') ADVANCE(69);
-      if (lookahead == ';') ADVANCE(83);
-      if (lookahead == '<') ADVANCE(139);
-      if (lookahead == '=') ADVANCE(136);
-      if (lookahead == '>') ADVANCE(48);
-      if (lookahead == '?') ADVANCE(54);
-      if (lookahead == 'E') ADVANCE(74);
-      if (lookahead == 'I') ADVANCE(71);
-      if (lookahead == 'N') ADVANCE(73);
-      if (lookahead == '[') ADVANCE(44);
-      if (lookahead == ']') ADVANCE(138);
-      if (lookahead == '_') ADVANCE(80);
-      if (lookahead == '|') ADVANCE(51);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(77);
-      if (lookahead == '-' ||
-          lookahead == '.' ||
-          lookahead == ':' ||
-          lookahead == 183) ADVANCE(79);
+      ADVANCE_MAP(
+        '"', 67,
+        '#', 72,
+        '%', 66,
+        '&', 121,
+        '\'', 81,
+        '(', 49,
+        ')', 52,
+        '*', 53,
+        '+', 55,
+        ',', 56,
+        '/', 70,
+        '1', 69,
+        ';', 83,
+        '<', 139,
+        '=', 136,
+        '>', 48,
+        '?', 54,
+        'E', 74,
+        'I', 71,
+        'N', 73,
+        '[', 44,
+        ']', 138,
+        '_', 80,
+        '|', 51,
+        '\t', 77,
+        '\n', 77,
+        '\r', 77,
+        ' ', 77,
+        '-', 79,
+        '.', 79,
+        ':', 79,
+        0xb7, 79,
+      );
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(78);
       if (('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
@@ -1655,25 +1639,27 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(68);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(67);
-      if (lookahead == '#') ADVANCE(28);
-      if (lookahead == '%') ADVANCE(66);
-      if (lookahead == '\'') ADVANCE(81);
-      if (lookahead == '(') ADVANCE(49);
-      if (lookahead == ')') ADVANCE(52);
-      if (lookahead == '*') ADVANCE(53);
-      if (lookahead == '+') ADVANCE(55);
-      if (lookahead == ',') ADVANCE(56);
-      if (lookahead == '/') ADVANCE(7);
-      if (lookahead == '>') ADVANCE(48);
-      if (lookahead == '?') ADVANCE(54);
-      if (lookahead == '[') ADVANCE(44);
-      if (lookahead == ']') ADVANCE(36);
-      if (lookahead == '|') ADVANCE(51);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(84);
+      ADVANCE_MAP(
+        '"', 67,
+        '#', 28,
+        '%', 66,
+        '\'', 81,
+        '(', 49,
+        ')', 52,
+        '*', 53,
+        '+', 55,
+        ',', 56,
+        '/', 7,
+        '>', 48,
+        '?', 54,
+        '[', 44,
+        ']', 36,
+        '|', 51,
+        '\t', 84,
+        '\n', 84,
+        '\r', 84,
+        ' ', 84,
+      );
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -1818,7 +1804,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 38:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(134);
@@ -1834,32 +1820,34 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 41:
       if (eof) ADVANCE(42);
-      if (lookahead == '"') ADVANCE(67);
-      if (lookahead == '#') ADVANCE(22);
-      if (lookahead == '%') ADVANCE(66);
-      if (lookahead == '\'') ADVANCE(81);
-      if (lookahead == '(') ADVANCE(49);
-      if (lookahead == ')') ADVANCE(52);
-      if (lookahead == '*') ADVANCE(53);
-      if (lookahead == '+') ADVANCE(55);
-      if (lookahead == ',') ADVANCE(56);
-      if (lookahead == '/') ADVANCE(7);
-      if (lookahead == '1') ADVANCE(6);
-      if (lookahead == ';') ADVANCE(83);
-      if (lookahead == '<') ADVANCE(140);
-      if (lookahead == '=') ADVANCE(136);
-      if (lookahead == '>') ADVANCE(48);
-      if (lookahead == '?') ADVANCE(54);
-      if (lookahead == 'E') ADVANCE(102);
-      if (lookahead == 'I') ADVANCE(85);
-      if (lookahead == 'N') ADVANCE(100);
-      if (lookahead == '[') ADVANCE(44);
-      if (lookahead == ']') ADVANCE(137);
-      if (lookahead == '|') ADVANCE(51);
-      if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(84);
+      ADVANCE_MAP(
+        '"', 67,
+        '#', 22,
+        '%', 66,
+        '\'', 81,
+        '(', 49,
+        ')', 52,
+        '*', 53,
+        '+', 55,
+        ',', 56,
+        '/', 7,
+        '1', 6,
+        ';', 83,
+        '<', 140,
+        '=', 136,
+        '>', 48,
+        '?', 54,
+        'E', 102,
+        'I', 85,
+        'N', 100,
+        '[', 44,
+        ']', 137,
+        '|', 51,
+        '\t', 84,
+        '\n', 84,
+        '\r', 84,
+        ' ', 84,
+      );
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(116);
@@ -1914,7 +1902,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == 'R') ADVANCE(86);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1931,13 +1919,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == 'S') ADVANCE(61);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1954,12 +1942,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_TokenizedType);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -1975,7 +1963,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(anon_sym_POUNDREQUIRED);
@@ -2006,7 +1994,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
@@ -2016,7 +2004,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'D') ADVANCE(57);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2035,7 +2023,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'M') ADVANCE(109);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2047,7 +2035,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == 'N') ADVANCE(108);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
@@ -2060,7 +2048,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 75:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
@@ -2073,7 +2061,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 76:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2099,7 +2087,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
@@ -2109,7 +2097,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_EntityValue_token1);
@@ -2119,7 +2107,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
@@ -2146,13 +2134,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(92);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2164,7 +2152,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(101);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2176,7 +2164,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'E') ADVANCE(106);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2193,7 +2181,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_Name);
@@ -2204,7 +2192,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_Name);
@@ -2215,13 +2203,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'F') ADVANCE(59);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2238,13 +2226,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'I') ADVANCE(110);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2257,7 +2245,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'I') ADVANCE(88);
       if (lookahead == 'Y') ADVANCE(61);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2274,7 +2262,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_Name);
@@ -2286,13 +2274,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'K') ADVANCE(87);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2309,7 +2297,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_Name);
@@ -2320,13 +2308,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'N') ADVANCE(59);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2343,7 +2331,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_Name);
@@ -2354,13 +2342,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'O') ADVANCE(98);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2377,13 +2365,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'S') ADVANCE(61);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2400,13 +2388,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(94);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2418,7 +2406,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(104);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2430,7 +2418,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == 'T') ADVANCE(95);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2447,7 +2435,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_Name);
@@ -2458,7 +2446,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_Name);
@@ -2469,12 +2457,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(114);
@@ -2487,7 +2475,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 115:
       ACCEPT_TOKEN(sym_Name);
       if (lookahead == ':' ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       if (lookahead == '-' ||
           lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
@@ -2503,7 +2491,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(116);
+          lookahead == 0xb7) ADVANCE(116);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2514,7 +2502,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2527,7 +2515,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2540,7 +2528,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('g' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_Nmtoken);
@@ -2550,7 +2538,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z') ||
-          lookahead == 183) ADVANCE(120);
+          lookahead == 0xb7) ADVANCE(120);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(anon_sym_AMP);
@@ -2591,11 +2579,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 130:
       ACCEPT_TOKEN(aux_sym_PubidLiteral_token1);
-      if (aux_sym_PubidLiteral_token1_character_set_1(lookahead)) ADVANCE(130);
+      if (set_contains(aux_sym_PubidLiteral_token1_character_set_1, 9, lookahead)) ADVANCE(130);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(aux_sym_PubidLiteral_token2);
-      if (aux_sym_PubidLiteral_token2_character_set_1(lookahead)) ADVANCE(131);
+      if (set_contains(aux_sym_PubidLiteral_token2_character_set_1, 9, lookahead)) ADVANCE(131);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(anon_sym_LT_QMARK);
@@ -2659,20 +2647,22 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (lookahead == 'A') ADVANCE(1);
-      if (lookahead == 'C') ADVANCE(2);
-      if (lookahead == 'D') ADVANCE(3);
-      if (lookahead == 'E') ADVANCE(4);
-      if (lookahead == 'I') ADVANCE(5);
-      if (lookahead == 'N') ADVANCE(6);
-      if (lookahead == 'P') ADVANCE(7);
-      if (lookahead == 'S') ADVANCE(8);
-      if (lookahead == 'e') ADVANCE(9);
-      if (lookahead == 'n') ADVANCE(10);
-      if (lookahead == 's') ADVANCE(11);
-      if (lookahead == 'v') ADVANCE(12);
-      if (lookahead == 'x') ADVANCE(13);
-      if (lookahead == 'y') ADVANCE(14);
+      ADVANCE_MAP(
+        'A', 1,
+        'C', 2,
+        'D', 3,
+        'E', 4,
+        'I', 5,
+        'N', 6,
+        'P', 7,
+        'S', 8,
+        'e', 9,
+        'n', 10,
+        's', 11,
+        'v', 12,
+        'x', 13,
+        'y', 14,
+      );
       END_STATE();
     case 1:
       if (lookahead == 'N') ADVANCE(15);
@@ -8021,15 +8011,15 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(480),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
   [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(441),
-  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(446),
-  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(445),
-  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(444),
-  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(443),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(442),
-  [46] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(475),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2),
-  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2), SHIFT_REPEAT(4),
-  [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_content, 1),
+  [31] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(446),
+  [34] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(445),
+  [37] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(444),
+  [40] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(443),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(442),
+  [46] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(475),
+  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0),
+  [51] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_content_repeat1, 2, 0, 0), SHIFT_REPEAT(4),
+  [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_content, 1, 0, 0),
   [56] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
   [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
   [60] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
@@ -8041,11 +8031,11 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(373),
   [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
   [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
-  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2), SHIFT_REPEAT(167),
-  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2), SHIFT_REPEAT(29),
-  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2), SHIFT_REPEAT(479),
-  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__intSubset, 2),
-  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2), SHIFT_REPEAT(287),
+  [78] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2, 0, 0), SHIFT_REPEAT(167),
+  [81] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2, 0, 0), SHIFT_REPEAT(29),
+  [84] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2, 0, 0), SHIFT_REPEAT(479),
+  [87] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__intSubset, 2, 0, 0),
+  [89] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__intSubset, 2, 0, 0), SHIFT_REPEAT(287),
   [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
   [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
   [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
@@ -8057,14 +8047,14 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(494),
   [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
   [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(273),
-  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 1),
-  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(491),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2),
-  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(22),
-  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(492),
-  [127] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(493),
-  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2), SHIFT_REPEAT(494),
-  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 1),
+  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 1, 0, 0),
+  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(491),
+  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0),
+  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(22),
+  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(492),
+  [127] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(493),
+  [130] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat2, 2, 0, 0), SHIFT_REPEAT(494),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 1, 0, 0),
   [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
   [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
   [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
@@ -8080,104 +8070,104 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(482),
   [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
   [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [165] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 2),
-  [167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(487),
-  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2),
-  [172] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(31),
-  [175] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(488),
-  [178] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(489),
-  [181] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2), SHIFT_REPEAT(490),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
-  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(32),
-  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(273),
-  [192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2),
-  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEReference, 3),
-  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2),
-  [198] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(476),
-  [201] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(477),
-  [204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(478),
-  [207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2), SHIFT_REPEAT(35),
-  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 4),
-  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 4),
-  [214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, .production_id = 1),
+  [165] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 2, 0, 0),
+  [167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(487),
+  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0),
+  [172] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(31),
+  [175] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(488),
+  [178] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(489),
+  [181] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EntityValue_repeat1, 2, 0, 0), SHIFT_REPEAT(490),
+  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(32),
+  [189] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(273),
+  [192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEReference, 3, 0, 0),
+  [196] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0),
+  [198] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(476),
+  [201] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(477),
+  [204] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(478),
+  [207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
+  [210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 4, 0, 0),
+  [212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 4, 0, 0),
+  [214] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 1),
   [216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(351),
   [218] = {.entry = {.count = 1, .reusable = false}}, SHIFT(476),
   [220] = {.entry = {.count = 1, .reusable = false}}, SHIFT(477),
   [222] = {.entry = {.count = 1, .reusable = true}}, SHIFT(478),
   [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, .production_id = 1),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 1),
   [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Reference, 1),
-  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__Reference, 1),
-  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2),
-  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(483),
-  [241] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(484),
-  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(485),
-  [247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2), SHIFT_REPEAT(43),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Reference, 1, 0, 0),
+  [234] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__Reference, 1, 0, 0),
+  [236] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0),
+  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(483),
+  [241] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(484),
+  [244] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(485),
+  [247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttValue_repeat2, 2, 0, 0), SHIFT_REPEAT(43),
   [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(349),
   [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [254] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, .production_id = 3),
+  [254] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, 0, 3),
   [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, .production_id = 2),
-  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ETag, 4),
-  [262] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ETag, 4),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3, 0, 2),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ETag, 4, 0, 0),
+  [262] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ETag, 4, 0, 0),
   [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
   [266] = {.entry = {.count = 1, .reusable = false}}, SHIFT(483),
   [268] = {.entry = {.count = 1, .reusable = false}}, SHIFT(484),
   [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(485),
   [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 5),
-  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 5),
-  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 5),
-  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 5),
-  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ETag, 3),
-  [284] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ETag, 3),
+  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 5, 0, 0),
+  [276] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 5, 0, 0),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 5, 0, 0),
+  [280] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 5, 0, 0),
+  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ETag, 3, 0, 0),
+  [284] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ETag, 3, 0, 0),
   [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
   [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
   [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
   [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
   [294] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
   [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 4),
-  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 4),
-  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 3),
-  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 3),
-  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 3),
-  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 3),
-  [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 3),
-  [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 3),
-  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 3),
-  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 3),
-  [318] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 3),
+  [298] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 4, 0, 0),
+  [300] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 4, 0, 0),
+  [302] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 3, 0, 0),
+  [304] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 3, 0, 0),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 3, 0, 0),
+  [308] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 3, 0, 0),
+  [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EmptyElemTag, 3, 0, 0),
+  [312] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EmptyElemTag, 3, 0, 0),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PI, 3, 0, 0),
+  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PI, 3, 0, 0),
+  [318] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 3, 0, 0),
   [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
-  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 2),
-  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 2),
-  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, .production_id = 2),
+  [322] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 2, 0, 0),
+  [324] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 2, 0, 0),
+  [326] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2, 0, 2),
   [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [330] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 1),
-  [332] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 1),
-  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 4),
-  [336] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDSect, 3),
-  [338] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CDSect, 3),
-  [340] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CharRef, 3),
-  [342] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CharRef, 3),
-  [344] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDSect, 2),
-  [346] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CDSect, 2),
-  [348] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 7),
-  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4, .production_id = 3),
-  [352] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityRef, 3),
-  [354] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EntityRef, 3),
-  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 4),
-  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 6),
+  [330] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_element, 1, 0, 0),
+  [332] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_element, 1, 0, 0),
+  [334] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 4, 0, 0),
+  [336] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDSect, 3, 0, 0),
+  [338] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CDSect, 3, 0, 0),
+  [340] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CharRef, 3, 0, 0),
+  [342] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CharRef, 3, 0, 0),
+  [344] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDSect, 2, 0, 0),
+  [346] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_CDSect, 2, 0, 0),
+  [348] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 7, 0, 0),
+  [350] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4, 0, 3),
+  [352] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityRef, 3, 0, 0),
+  [354] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_EntityRef, 3, 0, 0),
+  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_prolog, 4, 0, 0),
+  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 6, 0, 0),
   [360] = {.entry = {.count = 1, .reusable = true}}, SHIFT(238),
   [362] = {.entry = {.count = 1, .reusable = true}}, SHIFT(323),
   [364] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
   [366] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [368] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 3),
-  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 5),
-  [372] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 5),
-  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 5),
+  [368] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 3, 0, 0),
+  [370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_STag, 5, 0, 0),
+  [372] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_STag, 5, 0, 0),
+  [374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__choice, 5, 0, 0),
   [376] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
   [378] = {.entry = {.count = 1, .reusable = true}}, SHIFT(438),
   [380] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
@@ -8207,64 +8197,64 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
   [430] = {.entry = {.count = 1, .reusable = true}}, SHIFT(401),
   [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [434] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2), SHIFT_REPEAT(92),
-  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2),
-  [439] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2), SHIFT_REPEAT(357),
-  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEReference, 3),
-  [444] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 5),
-  [446] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 5),
-  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 5),
-  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 5),
+  [434] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0), SHIFT_REPEAT(92),
+  [437] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0),
+  [439] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 2, 0, 0), SHIFT_REPEAT(357),
+  [442] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_PEReference, 3, 0, 0),
+  [444] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 5, 0, 0),
+  [446] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 5, 0, 0),
+  [448] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 5, 0, 0),
+  [450] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 5, 0, 0),
   [452] = {.entry = {.count = 1, .reusable = true}}, SHIFT(463),
   [454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(456),
   [456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
   [458] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
   [460] = {.entry = {.count = 1, .reusable = true}}, SHIFT(465),
-  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 3),
-  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 3),
-  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 3),
-  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 3),
-  [470] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 4),
-  [472] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 4),
+  [462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 3, 0, 0),
+  [464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 3, 0, 0),
+  [466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 3, 0, 0),
+  [468] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 3, 0, 0),
+  [470] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XmlModelPI, 4, 0, 0),
+  [472] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XmlModelPI, 4, 0, 0),
   [474] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
   [476] = {.entry = {.count = 1, .reusable = true}}, SHIFT(195),
   [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(398),
   [480] = {.entry = {.count = 1, .reusable = true}}, SHIFT(336),
   [482] = {.entry = {.count = 1, .reusable = true}}, SHIFT(347),
-  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 4),
-  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 4),
-  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 2),
-  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 4),
-  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 4),
-  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 4),
+  [484] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StyleSheetPI, 4, 0, 0),
+  [486] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_StyleSheetPI, 4, 0, 0),
+  [488] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__cp, 2, 0, 0),
+  [490] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 4, 0, 0),
+  [492] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 4, 0, 0),
+  [494] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 4, 0, 0),
   [496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
   [498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
   [500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
   [502] = {.entry = {.count = 1, .reusable = true}}, SHIFT(222),
-  [504] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 6),
-  [506] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 6),
-  [508] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2),
-  [510] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(195),
-  [513] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(398),
-  [516] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 1),
+  [504] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 6, 0, 0),
+  [506] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 6, 0, 0),
+  [508] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0),
+  [510] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(195),
+  [513] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(398),
+  [516] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 1, 0, 0),
   [518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
   [520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(383),
-  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 3),
-  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2),
-  [526] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2), SHIFT_REPEAT(482),
-  [529] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2), SHIFT_REPEAT(358),
+  [522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat1, 3, 0, 0),
+  [524] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0),
+  [526] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0), SHIFT_REPEAT(482),
+  [529] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__choice_repeat2, 2, 0, 0), SHIFT_REPEAT(358),
   [532] = {.entry = {.count = 1, .reusable = true}}, SHIFT(223),
-  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__intSubset, 3),
+  [534] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__intSubset, 3, 0, 0),
   [536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
   [538] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
   [540] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 7),
-  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 7),
-  [546] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2), SHIFT_REPEAT(174),
-  [549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2),
-  [551] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2), SHIFT_REPEAT(396),
-  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 5),
-  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 5),
+  [542] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 7, 0, 0),
+  [544] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 7, 0, 0),
+  [546] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0), SHIFT_REPEAT(174),
+  [549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0),
+  [551] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 2, 0, 0), SHIFT_REPEAT(396),
+  [554] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_XMLDecl, 5, 0, 0),
+  [556] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_XMLDecl, 5, 0, 0),
   [558] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
   [560] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
   [562] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
@@ -8281,8 +8271,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [584] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
   [586] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
   [588] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 12),
-  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 12),
+  [590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 12, 0, 0),
+  [592] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 12, 0, 0),
   [594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(399),
   [596] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
   [598] = {.entry = {.count = 1, .reusable = true}}, SHIFT(388),
@@ -8293,53 +8283,53 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
   [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(201),
   [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
-  [614] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 8),
-  [616] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 8),
+  [614] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 8, 0, 0),
+  [616] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 8, 0, 0),
   [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(226),
   [620] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [622] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2),
-  [624] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2), SHIFT_REPEAT(482),
-  [627] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 11),
-  [629] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 11),
-  [631] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 5),
-  [633] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 5),
+  [622] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2, 0, 0),
+  [624] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 2, 0, 0), SHIFT_REPEAT(482),
+  [627] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 11, 0, 0),
+  [629] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 11, 0, 0),
+  [631] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 5, 0, 0),
+  [633] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 5, 0, 0),
   [635] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
   [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
-  [639] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 3),
-  [641] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2), SHIFT_REPEAT(188),
+  [639] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 3, 0, 0),
+  [641] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
   [644] = {.entry = {.count = 1, .reusable = true}}, SHIFT(416),
-  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EmptyElemTag_repeat1, 2),
-  [648] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EmptyElemTag_repeat1, 2), SHIFT_REPEAT(288),
+  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_EmptyElemTag_repeat1, 2, 0, 0),
+  [648] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_EmptyElemTag_repeat1, 2, 0, 0), SHIFT_REPEAT(288),
   [651] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1),
-  [655] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1), SHIFT_REPEAT(192),
-  [658] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2),
-  [660] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2), SHIFT_REPEAT(262),
+  [653] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1, 0, 0),
+  [655] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_NotationType_repeat1, 1, 0, 0), SHIFT_REPEAT(192),
+  [658] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0),
+  [660] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0), SHIFT_REPEAT(262),
   [663] = {.entry = {.count = 1, .reusable = true}}, SHIFT(402),
   [665] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
-  [667] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 7),
-  [669] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 7),
+  [667] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 7, 0, 0),
+  [669] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 7, 0, 0),
   [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
   [673] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
   [675] = {.entry = {.count = 1, .reusable = true}}, SHIFT(362),
-  [677] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 3),
+  [677] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 3, 0, 0),
   [679] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
   [681] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [683] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2), SHIFT_REPEAT(360),
-  [686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2),
-  [688] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2), SHIFT_REPEAT(395),
+  [683] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0), SHIFT_REPEAT(360),
+  [686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0),
+  [688] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 2, 0, 0), SHIFT_REPEAT(395),
   [691] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
-  [693] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 9),
-  [695] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 9),
+  [693] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 9, 0, 0),
+  [695] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 9, 0, 0),
   [697] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
   [699] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
-  [701] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 10),
-  [703] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 10),
+  [701] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 10, 0, 0),
+  [703] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 10, 0, 0),
   [705] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
   [707] = {.entry = {.count = 1, .reusable = true}}, SHIFT(197),
-  [709] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 6),
-  [711] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 6),
-  [713] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 4),
+  [709] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_doctypedecl, 6, 0, 0),
+  [711] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_doctypedecl, 6, 0, 0),
+  [713] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat1, 4, 0, 0),
   [715] = {.entry = {.count = 1, .reusable = false}}, SHIFT(280),
   [717] = {.entry = {.count = 1, .reusable = true}}, SHIFT(275),
   [719] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
@@ -8348,7 +8338,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [725] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
   [727] = {.entry = {.count = 1, .reusable = true}}, SHIFT(427),
   [729] = {.entry = {.count = 1, .reusable = true}}, SHIFT(426),
-  [731] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 6),
+  [731] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 6, 0, 0),
   [733] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
   [735] = {.entry = {.count = 1, .reusable = true}}, SHIFT(428),
   [737] = {.entry = {.count = 1, .reusable = true}}, SHIFT(250),
@@ -8357,41 +8347,41 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [743] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
   [745] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
   [747] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [749] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_StyleSheetPI_repeat1, 2), SHIFT_REPEAT(290),
-  [752] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_StyleSheetPI_repeat1, 2),
+  [749] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_StyleSheetPI_repeat1, 2, 0, 0), SHIFT_REPEAT(290),
+  [752] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_StyleSheetPI_repeat1, 2, 0, 0),
   [754] = {.entry = {.count = 1, .reusable = true}}, SHIFT(251),
   [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [758] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_SystemLiteral, 3),
+  [758] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_SystemLiteral, 3, 0, 0),
   [760] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [762] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 5),
+  [762] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 5, 0, 0),
   [764] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [766] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 5),
+  [766] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 5, 0, 0),
   [768] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
   [770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(214),
-  [772] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Attribute, 3),
+  [772] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Attribute, 3, 0, 0),
   [774] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
-  [776] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 3, .production_id = 4),
-  [778] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 3),
+  [776] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 3, 0, 4),
+  [778] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 3, 0, 0),
   [780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
   [782] = {.entry = {.count = 1, .reusable = true}}, SHIFT(183),
   [784] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [786] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 4),
-  [788] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 3),
+  [786] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Enumeration_repeat1, 4, 0, 0),
+  [788] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ExternalID, 3, 0, 0),
   [790] = {.entry = {.count = 1, .reusable = true}}, SHIFT(228),
   [792] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
   [794] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
   [796] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
-  [798] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 1),
+  [798] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 1, 0, 0),
   [800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(313),
   [802] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
   [804] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
   [806] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
   [808] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
-  [810] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 4),
+  [810] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 4, 0, 0),
   [812] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
   [814] = {.entry = {.count = 1, .reusable = true}}, SHIFT(437),
   [816] = {.entry = {.count = 1, .reusable = true}}, SHIFT(202),
-  [818] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 2),
+  [818] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 2, 0, 0),
   [820] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
   [822] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
   [824] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
@@ -8403,56 +8393,56 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [836] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
   [838] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
   [840] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
-  [842] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 3),
+  [842] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 3, 0, 0),
   [844] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
-  [846] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 2),
-  [848] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 1),
+  [846] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttValue, 2, 0, 0),
+  [848] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_Mixed_repeat2, 1, 0, 0),
   [850] = {.entry = {.count = 1, .reusable = true}}, SHIFT(315),
   [852] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
   [854] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
   [856] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
   [858] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [860] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 6),
-  [862] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 2),
+  [860] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 6, 0, 0),
+  [862] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 2, 0, 0),
   [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(486),
   [866] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
   [868] = {.entry = {.count = 1, .reusable = true}}, SHIFT(435),
-  [870] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 7),
+  [870] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 7, 0, 0),
   [872] = {.entry = {.count = 1, .reusable = true}}, SHIFT(400),
   [874] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
   [876] = {.entry = {.count = 1, .reusable = true}}, SHIFT(449),
   [878] = {.entry = {.count = 1, .reusable = true}}, SHIFT(447),
-  [880] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EntityDecl, 1),
+  [880] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EntityDecl, 1, 0, 0),
   [882] = {.entry = {.count = 1, .reusable = true}}, SHIFT(411),
-  [884] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__markupdecl, 1),
+  [884] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__markupdecl, 1, 0, 0),
   [886] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
   [888] = {.entry = {.count = 1, .reusable = true}}, SHIFT(459),
-  [890] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 7),
-  [892] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 8),
+  [890] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 7, 0, 0),
+  [892] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 8, 0, 0),
   [894] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
   [896] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
   [898] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
-  [900] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__AttType, 1),
-  [902] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 4),
+  [900] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__AttType, 1, 0, 0),
+  [902] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 4, 0, 0),
   [904] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EnumeratedType, 1),
-  [908] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PublicID, 3),
+  [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EnumeratedType, 1, 0, 0),
+  [908] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PublicID, 3, 0, 0),
   [910] = {.entry = {.count = 1, .reusable = true}}, SHIFT(218),
-  [912] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 8),
+  [912] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationDecl, 8, 0, 0),
   [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(338),
   [916] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
-  [918] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 3, .production_id = 4),
-  [920] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAttValue, 2),
+  [918] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_EntityValue, 3, 0, 4),
+  [920] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAttValue, 2, 0, 0),
   [922] = {.entry = {.count = 1, .reusable = true}}, SHIFT(432),
   [924] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [926] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 8),
+  [926] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 8, 0, 0),
   [928] = {.entry = {.count = 1, .reusable = true}}, SHIFT(481),
   [930] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
   [932] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
   [934] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [936] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 7),
-  [938] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 2),
-  [940] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StringType, 1),
+  [936] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 7, 0, 0),
+  [938] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_children, 2, 0, 0),
+  [940] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_StringType, 1, 0, 0),
   [942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
   [944] = {.entry = {.count = 1, .reusable = true}}, SHIFT(406),
   [946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(461),
@@ -8465,54 +8455,54 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [960] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
   [962] = {.entry = {.count = 1, .reusable = true}}, SHIFT(185),
   [964] = {.entry = {.count = 1, .reusable = true}}, SHIFT(418),
-  [966] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 9),
+  [966] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 9, 0, 0),
   [968] = {.entry = {.count = 1, .reusable = true}}, SHIFT(458),
-  [970] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDStart, 3),
-  [972] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 8),
-  [974] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAtt, 3),
+  [970] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_CDStart, 3, 0, 0),
+  [972] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 8, 0, 0),
+  [974] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAtt, 3, 0, 0),
   [976] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
   [978] = {.entry = {.count = 1, .reusable = true}}, SHIFT(417),
   [980] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
   [982] = {.entry = {.count = 1, .reusable = true}}, SHIFT(439),
-  [984] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 7),
-  [986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 3),
-  [988] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__VersionInfo, 6),
+  [984] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NotationType, 7, 0, 0),
+  [986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__Eq, 3, 0, 0),
+  [988] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__VersionInfo, 6, 0, 0),
   [990] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
   [992] = {.entry = {.count = 1, .reusable = true}}, SHIFT(413),
   [994] = {.entry = {.count = 1, .reusable = true}}, SHIFT(434),
   [996] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [998] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 9),
-  [1000] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 6),
-  [1002] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2), SHIFT(27),
-  [1005] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 9),
-  [1007] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 8),
-  [1009] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 6),
+  [998] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 9, 0, 0),
+  [1000] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 6, 0, 0),
+  [1002] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_AttlistDecl_repeat1, 2, 0, 0), SHIFT(27),
+  [1005] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_GEDecl, 9, 0, 0),
+  [1007] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 8, 0, 0),
+  [1009] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 6, 0, 0),
   [1011] = {.entry = {.count = 1, .reusable = true}}, SHIFT(348),
   [1013] = {.entry = {.count = 1, .reusable = true}}, SHIFT(453),
-  [1015] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 3),
+  [1015] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 3, 0, 0),
   [1017] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
   [1019] = {.entry = {.count = 1, .reusable = true}}, SHIFT(410),
-  [1021] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 7),
-  [1023] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_contentspec, 1),
+  [1021] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elementdecl, 7, 0, 0),
+  [1023] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_contentspec, 1, 0, 0),
   [1025] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
   [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(419),
-  [1029] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAttValue, 3, .production_id = 4),
-  [1031] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PubidLiteral, 3),
+  [1029] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PseudoAttValue, 3, 0, 4),
+  [1031] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PubidLiteral, 3, 0, 0),
   [1033] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
   [1035] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
-  [1037] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 5),
-  [1039] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 7),
-  [1041] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 5),
+  [1037] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 5, 0, 0),
+  [1039] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Mixed, 7, 0, 0),
+  [1041] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttlistDecl, 5, 0, 0),
   [1043] = {.entry = {.count = 1, .reusable = true}}, SHIFT(381),
   [1045] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
-  [1047] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 3),
-  [1049] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__SDDecl, 6),
-  [1051] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EncodingDecl, 6),
-  [1053] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 1),
+  [1047] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 3, 0, 0),
+  [1049] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__SDDecl, 6, 0, 0),
+  [1051] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__EncodingDecl, 6, 0, 0),
+  [1053] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_DefaultDecl, 1, 0, 0),
   [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(450),
-  [1057] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 6),
-  [1059] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 10),
-  [1061] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NDataDecl, 4),
+  [1057] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_AttDef, 6, 0, 0),
+  [1059] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_PEDecl, 10, 0, 0),
+  [1061] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_NDataDecl, 4, 0, 0),
   [1063] = {.entry = {.count = 1, .reusable = true}}, SHIFT(464),
   [1065] = {.entry = {.count = 1, .reusable = true}}, SHIFT(391),
   [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(394),
@@ -8520,7 +8510,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(208),
   [1073] = {.entry = {.count = 1, .reusable = true}}, SHIFT(378),
   [1075] = {.entry = {.count = 1, .reusable = true}}, SHIFT(440),
-  [1077] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 4),
+  [1077] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_Enumeration, 4, 0, 0),
   [1079] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
   [1081] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
   [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
@@ -8706,7 +8696,7 @@ void tree_sitter_xml_external_scanner_deserialize(void *, const char *, unsigned
 #define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_xml() {
+TS_PUBLIC const TSLanguage *tree_sitter_xml(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/xml/src/tree_sitter/parser.h
+++ b/xml/src/tree_sitter/parser.h
@@ -86,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -125,6 +130,24 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
@@ -152,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -203,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \


### PR DESCRIPTION
Closes #20

@cdacamar can you try this branch out and see if you still get the inconsistent parsing behavior?

I believe the issue stems from [asan hooking and changing strcmp](https://stackoverflow.com/questions/49213586/strcmp-returns-different-result-under-fsanitize-address), and I'm assuming the windows implementation is similar to this one, or at the very least not like the typical glibc strcmp - hence the extremely bizarre inconsistency. I noticed that the external lexer was *not* returning the ending tag name after lexing it, which was weird. So I changed the string logic to be simpler and more akin to html's, seems to be good on my end