### PR TITLE
fix(scanner): correct out of bounds access in tree_sitter_xml_external_scanner_serialize

### DIFF
--- a/xml/src/scanner.c
+++ b/xml/src/scanner.c
@@ -204,9 +204,9 @@ void tree_sitter_xml_external_scanner_destroy(void *payload) {
 unsigned tree_sitter_xml_external_scanner_serialize(void *payload, char *buffer) {
     Vector *tags = (Vector *)payload;
     uint32_t tag_count = tags->size > UINT16_MAX ? UINT16_MAX : tags->size;
-    uint32_t serialized_tag_count = 0, size = sizeof tag_count;
+    uint32_t serialized_tag_count = 0, size = 0;
 
-    memcpy(&buffer[size], &tag_count, size);
+    memcpy(&buffer[size], &tag_count, sizeof tag_count);
     size += sizeof tag_count;
 
     for (; serialized_tag_count < tag_count; ++serialized_tag_count) {


### PR DESCRIPTION
This just corrects a simple OOB access in the external scanner's serialize function. We started indexing the serialization buffer at `sizeof tag_count` rather than `0`, leading to the subsequent bounds check against `TREE_SITTER_SERIALIZATION_BUFFER_SIZE` to be slightly off.

Edit: Not so simple apparently.

- Fixes https://github.com/tree-sitter/tree-sitter/issues/4813